### PR TITLE
[@types/leaflet-routing-machine] Fixed "text" type in IInstruction interface.

### DIFF
--- a/types/leaflet-routing-machine/index.d.ts
+++ b/types/leaflet-routing-machine/index.d.ts
@@ -216,7 +216,7 @@ declare module 'leaflet' {
         interface IInstruction {
             distance: number;
             time: number;
-            text?: number;
+            text?: string;
             type?: 'Straight' | 'SlightRight' | 'Right' | 'SharpRight' | 'TurnAround' | 'SharpLeft' | 'Left' | 'SlightLeft' | 'WaypointReached' |
                 'Roundabout' | 'StartAt' | 'DestinationReached' | 'EnterAgainstAllowedDirection' | 'LeaveAgainstAllowedDirection';
             road?: string;


### PR DESCRIPTION
I don't believe that the text property should be a number. It was throwing compiler errors before, but when I changed it to a string in a personal project it worked perfectly.

Please fill in this template.

- [Y]  Use a meaningful title for the pull request. Include the name of the package modified.
- [Y] Test the change in your own code. (Compile and run.)
- [N] Add or edit tests to reflect the change. (Run with `npm test`.)
- [Y] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [Y] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [N] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [Y] Provide a URL to documentation or source code which provides context for the suggested changes: [API Definitions](http://www.liedman.net/leaflet-routing-machine/api/#iinstruction)
- [N] Increase the version number in the header if appropriate.
- [N] If you are making substantial changes, consider adding a `tslint.json` containing `{ "extends": "dtslint/dt.json" }`.

